### PR TITLE
npm version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yelda-webchat",
-  "version": "1.0.53",
+  "version": "1.0.55",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yelda-webchat",
-  "version": "1.0.53",
+  "version": "1.0.55",
   "description": "Website Chat Plugin",
   "main": "./dist/js/yeldaWebchatInjector.min.js",
   "license": "MIT",


### PR DESCRIPTION
I had a mistake in the script at first with the upload to S3 so I run the script a second time which explains why the version went from 1.0.53 to 1.0.55

Maybe we could move the publish step at the end of the script? This way, if any error occurs before, it won't publish the package?