### PR TITLE
republish last version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yelda-webchat",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yelda-webchat",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "description": "Website Chat Plugin",
   "main": "./dist/js/yeldaWebchatInjector.min.js",
   "license": "MIT",


### PR DESCRIPTION
Probably linked to all the issues I had yesterday, the last published version (1.0.55) did not contained the new built files and therefore did not contain the fix for https://github.com/Yeldaai/yelda/issues/3633
So I republished and now it contains the last version

Sorry for all these back and forth!