### PR TITLE
remove debugs incorrectly commited while publishing an new version

### DIFF
--- a/uploadBuildToS3.js
+++ b/uploadBuildToS3.js
@@ -42,13 +42,11 @@ const argv = yargs
     })
     .argv
 
-    console.log(argv)
-
 const main = async () => {
   try {
     // Check if there are any change that has not been committed before starting the script
     if (!(await checkIfAllChangesCommitted())) {
-      //throw new Error('Some changes are not committed. Commit your changes or stash them before running this script.')
+      throw new Error('Some changes are not committed. Commit your changes or stash them before running this script.')
     }
 
     await uploadToS3()


### PR DESCRIPTION
Sorry for the last 6 commits :/
I was debugging the "otp", the one time password requirement recently added by npm to publish package, and i did not realized that i was pushing commits to master at the same time ><

So in short this PR remove the last debugs + 
has as an objective to share the news with you 
```
npm run uploadBuildToS3 --semver=patch --destinationPath=/var/www/yelda/yelda/frontend/static -o 695912
```

the -o allow us to add the npm otp so it would be added to the `npm publish` command
thanks